### PR TITLE
Converts to contacts map and subscriber set

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install @astrouxds/mock-data
 
 ## Getting Started
 
-The example below creates a state object with the generated contacts and maps the alerts connected to those contacts on an alerts property.
+The example below creates a state object with the generated contacts and maps the alerts and mnemonics connected to those contacts on their respective properties.
 
 ```ts
 import { generateContacts } from '@astrouxds/mock-data';
@@ -139,6 +139,68 @@ const App = () => {
 
 export default App;
 ```
+
+## Contacts Service
+
+Class based store for instaciating then subscribing to an auto-generate contacts state
+
+```ts
+import { ContactsService } from '@astrouxds/mock-data';
+```
+
+```ts
+// with manually set options
+const contactsService = new ContactsService({
+  initial: 10,
+  interval: 2,
+  limit: 20,
+});
+
+let contacts: Map<string, Contact> = new Map();
+const unsubscribe = contactsService.subscribe((data) => {
+  contacts = data;
+});
+```
+
+Use the unsubscribe function returned from contactsService.subscribe to unsubscribe
+
+```ts
+setTimeout(() => {
+  unsubscribe();
+}, 1000 * 60 * 5); // unsubscribe after 5 mins
+```
+
+## Contacts Service Example With React
+
+```ts
+import { useSyncExternalStore } from 'react';
+import { ContactsService } from '@astrouxds/mock-data';
+
+const contactsService = new ContactsService({
+  initial: 10,
+  interval: 2,
+  limit: 20,
+});
+
+const App = () => {
+  const contacts = useSyncExternalStore(
+    contactService.subscribe,
+    contactsService.getContacts,
+  );
+
+  return (
+    <ul>
+      {contacts.map(({ id, equipment }) => (
+        <li key={id}>{equipment}</li>
+      ))}
+    </ul>
+  );
+};
+
+export default App;
+```
+
+- The useSyncExternalStore hook takes two arguments (subscribe function, getSnapshot function) and one optional argument (getServerSnapshot function). The getServerSnapshot function is not supported and therefore SSR is not supported at this time.
 
 ## API
 

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -70,9 +70,9 @@ const contactsService = new ContactsService({
   limit: 20,
 });
 
-let contacts: Contact[] = [];
+let contacts: Map<string, Contact> = new Map();
 const unsubscribe = contactsService.subscribe((data) => {
-  console.log(data.length);
+  console.log(data.size);
   contacts = data;
 });
 
@@ -82,13 +82,19 @@ setTimeout(() => {
 }, 1000 * 60 * 5);
 
 setTimeout(() => {
-  const id = contacts[between({ min: 0, max: contacts.length - 1 })].id;
+  const lastKey = Array.from(contacts.keys()).pop();
+  if (!lastKey) return;
+  const id = contacts.get(lastKey)?.id;
+  if (!id) return;
   console.log('[Removed Contact]:', id);
   contactsService.deleteContact(id);
 }, 1000 * 5);
 
 setTimeout(() => {
-  const id = contacts[between({ min: 0, max: contacts.length - 1 })].id;
+  const lastKey = Array.from(contacts.keys()).pop();
+  if (!lastKey) return;
+  const id = contacts.get(lastKey)?.id;
+  if (!id) return;
   console.log('[Modified Contact]:', id);
   contactsService.modifyContact({
     id,

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -104,6 +104,7 @@ setTimeout(() => {
 }, 1000 * 7);
 
 setTimeout(() => {
+  console.log(contactsService.getContacts());
   contactsService.addContact();
   contactsService.addContact();
   contactsService.addContact();

--- a/src/services/contacts-service.ts
+++ b/src/services/contacts-service.ts
@@ -9,10 +9,12 @@ import type {
   Unsubscribe,
 } from '../types';
 
+type ContactsMap = Map<string, Contact>;
+type SubscribersSet = { [key: string]: Set<Function> };
 export class ContactsService {
-  private _data: Map<string, Contact> = new Map();
+  private _data: ContactsMap = new Map();
   private _eventName = 'contacts';
-  private _subscribers: { [key: string]: Set<Function> } = {};
+  private _subscribers: SubscribersSet = {};
   private _contactOptions: ContactOptions = {};
   private _subscribeOptions: SubscribeOptions = {};
 
@@ -31,11 +33,7 @@ export class ContactsService {
     };
   }
 
-  // private _findIndex(id: string): number {
-  //   return this._data.findIndex((contact) => contact.id === id);
-  // }
-
-  private _publish = (contacts: Map<string, Contact>) => {
+  private _publish = (contacts: ContactsMap) => {
     if (!(this._eventName in this._subscribers)) return;
 
     this._subscribers[this._eventName].forEach((callback) => {
@@ -44,7 +42,7 @@ export class ContactsService {
   };
 
   public subscribe = (
-    callback: (contacts: Map<string, Contact>) => void,
+    callback: (contacts: ContactsMap) => void,
   ): Unsubscribe => {
     if (!(this._eventName in this._subscribers)) {
       this._subscribers[this._eventName] = new Set<Function>();
@@ -69,7 +67,7 @@ export class ContactsService {
     };
   };
 
-  public getContacts = (): Map<string, Contact> => {
+  public getContacts = (): ContactsMap => {
     return this._data;
   };
 

--- a/src/services/contacts-service.ts
+++ b/src/services/contacts-service.ts
@@ -69,6 +69,10 @@ export class ContactsService {
     };
   };
 
+  public getContacts = (): Map<string, Contact> => {
+    return this._data;
+  };
+
   public addContact = (): Contact => {
     const index = this._data.size - 1;
     const addedContact = generateContact(index, this._contactOptions);

--- a/src/services/contacts-service.ts
+++ b/src/services/contacts-service.ts
@@ -12,11 +12,9 @@ import type {
 } from '../types';
 
 type ContactsMap = Map<string, Contact>;
-type SubscribersSet = { [key: string]: Set<Function> };
 export class ContactsService {
   private _data: ContactsMap = new Map();
-  private _eventName = 'contacts';
-  private _subscribers: SubscribersSet = {};
+  private _subscribers: Set<Function> = new Set();
   private _contactOptions: ContactOptions = {};
   private _subscribeOptions: SubscribeOptions = {};
 
@@ -36,9 +34,7 @@ export class ContactsService {
   }
 
   private _publish = (contacts: ContactsMap) => {
-    if (!(this._eventName in this._subscribers)) return;
-
-    this._subscribers[this._eventName].forEach((callback) => {
+    this._subscribers.forEach((callback) => {
       callback(contacts);
     });
   };
@@ -46,11 +42,7 @@ export class ContactsService {
   public subscribe = (
     callback: (contacts: ContactsMap) => void,
   ): Unsubscribe => {
-    if (!(this._eventName in this._subscribers)) {
-      this._subscribers[this._eventName] = new Set<Function>();
-    }
-
-    this._subscribers[this._eventName].add(callback);
+    this._subscribers.add(callback);
     const initial = this._subscribeOptions.initial;
     const contactsArray = generateContacts(initial, this._contactOptions);
     contactsArray.forEach((contact) => this._data.set(contact.id, contact));
@@ -65,7 +57,7 @@ export class ContactsService {
 
     return () => {
       clearInterval(interval);
-      this._subscribers[this._eventName].delete(callback);
+      this._subscribers.delete(callback);
     };
   };
 

--- a/src/services/contacts-service.ts
+++ b/src/services/contacts-service.ts
@@ -10,9 +10,9 @@ import type {
 } from '../types';
 
 export class ContactsService {
-  private _data: Contact[] = [];
+  private _data: Map<string, Contact> = new Map();
   private _eventName = 'contacts';
-  private _subscribers: { [key: string]: Function[] } = {};
+  private _subscribers: { [key: string]: Set<Function> } = {};
   private _contactOptions: ContactOptions = {};
   private _subscribeOptions: SubscribeOptions = {};
 
@@ -31,62 +31,65 @@ export class ContactsService {
     };
   }
 
-  private _findIndex(id: string): number {
-    return this._data.findIndex((contact) => contact.id === id);
-  }
+  // private _findIndex(id: string): number {
+  //   return this._data.findIndex((contact) => contact.id === id);
+  // }
 
-  private _publish(contacts: Contact[]) {
-    if (!Array.isArray(this._subscribers[this._eventName])) return;
+  private _publish(contacts: Map<string, Contact>) {
+    if (!(this._eventName in this._subscribers)) return;
 
     this._subscribers[this._eventName].forEach((callback) => {
       callback(contacts);
     });
   }
 
-  public subscribe(callback: (contacts: Contact[]) => void): Unsubscribe {
-    if (!Array.isArray(this._subscribers[this._eventName])) {
-      this._subscribers[this._eventName] = [];
+  public subscribe(
+    callback: (contacts: Map<string, Contact>) => void,
+  ): Unsubscribe {
+    if (!(this._eventName in this._subscribers)) {
+      this._subscribers[this._eventName] = new Set<Function>();
     }
 
-    this._subscribers[this._eventName].push(callback);
+    this._subscribers[this._eventName].add(callback);
     const initial = this._subscribeOptions.initial;
-    this._data = generateContacts(initial, this._contactOptions);
+    const contactsArray = generateContacts(initial, this._contactOptions);
+    contactsArray.forEach((contact) => this._data.set(contact.id, contact));
     this._publish(this._data);
 
     const limit = this._subscribeOptions.limit || 200;
-    const index = this._subscribers[this._eventName].length - 1;
+
     const interval = setInterval(() => {
-      if (this._data.length >= limit) return;
+      if (this._data.size >= limit) return;
       this.addContact();
     }, (this._subscribeOptions.interval || 5) * 1000);
 
     return () => {
       clearInterval(interval);
-      this._subscribers[this._eventName].splice(index, 1);
+      this._subscribers[this._eventName].delete(callback);
     };
   }
 
   public addContact(): Contact {
-    const index = this._data.length - 1;
+    const index = this._data.size - 1;
     const addedContact = generateContact(index, this._contactOptions);
-    this._data = [...this._data, addedContact];
+    this._data.set(addedContact.id, addedContact);
     this._publish(this._data);
     return addedContact;
   }
 
   public modifyContact(params: ModifyContactParams): string {
-    const index = this._findIndex(params.id);
-    Object.entries(params).forEach(([key, value]) => {
-      // @ts-expect-error key will be a contact property
-      this._data[index][key] = value;
-    });
+    const currentContact = this._data.get(params.id);
+    if (!currentContact) return `Contact with id ${params.id} does not exist`;
+
+    const modifiedContact = { ...currentContact, ...params };
+    this._data.set(params.id, modifiedContact);
+
     this._publish(this._data);
     return `Successfully modified contact: ${params.id}`;
   }
 
   public deleteContact(id: string): string {
-    const index = this._findIndex(id);
-    this._data.splice(index, 1);
+    this._data.delete(id);
     this._publish(this._data);
     return `Successfully deleted contact: ${id}`;
   }

--- a/src/services/contacts-service.ts
+++ b/src/services/contacts-service.ts
@@ -67,8 +67,15 @@ export class ContactsService {
     };
   };
 
-  public getContacts = (): ContactsMap => {
-    return this._data;
+  public getContacts = (): {
+    contacts: Contact[];
+    contactsById: { [key: string]: Contact };
+    contactIds: string[];
+  } => {
+    const contacts = Array.from(this._data.values());
+    const contactsById = Object.fromEntries(this._data);
+    const contactIds = Array.from(this._data.keys());
+    return { contacts, contactsById, contactIds };
   };
 
   public addContact = (): Contact => {

--- a/src/services/contacts-service.ts
+++ b/src/services/contacts-service.ts
@@ -35,17 +35,17 @@ export class ContactsService {
   //   return this._data.findIndex((contact) => contact.id === id);
   // }
 
-  private _publish(contacts: Map<string, Contact>) {
+  private _publish = (contacts: Map<string, Contact>) => {
     if (!(this._eventName in this._subscribers)) return;
 
     this._subscribers[this._eventName].forEach((callback) => {
       callback(contacts);
     });
-  }
+  };
 
-  public subscribe(
+  public subscribe = (
     callback: (contacts: Map<string, Contact>) => void,
-  ): Unsubscribe {
+  ): Unsubscribe => {
     if (!(this._eventName in this._subscribers)) {
       this._subscribers[this._eventName] = new Set<Function>();
     }
@@ -67,17 +67,17 @@ export class ContactsService {
       clearInterval(interval);
       this._subscribers[this._eventName].delete(callback);
     };
-  }
+  };
 
-  public addContact(): Contact {
+  public addContact = (): Contact => {
     const index = this._data.size - 1;
     const addedContact = generateContact(index, this._contactOptions);
     this._data.set(addedContact.id, addedContact);
     this._publish(this._data);
     return addedContact;
-  }
+  };
 
-  public modifyContact(params: ModifyContactParams): string {
+  public modifyContact = (params: ModifyContactParams): string => {
     const currentContact = this._data.get(params.id);
     if (!currentContact) return `Contact with id ${params.id} does not exist`;
 
@@ -86,11 +86,11 @@ export class ContactsService {
 
     this._publish(this._data);
     return `Successfully modified contact: ${params.id}`;
-  }
+  };
 
-  public deleteContact(id: string): string {
+  public deleteContact = (id: string): string => {
     this._data.delete(id);
     this._publish(this._data);
     return `Successfully deleted contact: ${id}`;
-  }
+  };
 }

--- a/src/services/contacts-service.ts
+++ b/src/services/contacts-service.ts
@@ -7,6 +7,8 @@ import type {
   ModifyContactParams,
   SubscribeOptions,
   Unsubscribe,
+  Alert,
+  Mnemonic,
 } from '../types';
 
 type ContactsMap = Map<string, Contact>;
@@ -101,5 +103,35 @@ export class ContactsService {
     this._data.delete(id);
     this._publish(this._data);
     return `Successfully deleted contact: ${id}`;
+  };
+
+  public selectAlerts = () => {
+    const alerts = Array.from(this._data.values()).flatMap(
+      (contact) => contact.alerts,
+    );
+    const alertsById = alerts.reduce(
+      (alertsById: { [key: string]: Alert }, currentValue) => {
+        alertsById[currentValue.id] = currentValue;
+        return alertsById;
+      },
+      {},
+    );
+    const alertIds = alerts.map((alert) => alert.id);
+    return { alerts, alertsById, alertIds };
+  };
+
+  public selectMnemonics = () => {
+    const mnemonics = Array.from(this._data.values()).flatMap(
+      (contact) => contact.mnemonics,
+    );
+    const mnemonicsById = mnemonics.reduce(
+      (mnemonicsById: { [key: string]: Mnemonic }, currentValue) => {
+        mnemonicsById[currentValue.id] = currentValue;
+        return mnemonicsById;
+      },
+      {},
+    );
+    const mnemonicIds = mnemonics.map((mnemonic) => mnemonic.id);
+    return { mnemonics, mnemonicsById, mnemonicIds };
   };
 }


### PR DESCRIPTION
- Converts contacts data to a Map data structure to provide better performance and security
- Converts subscriber list to a Set to prevent duplication
- Converts class methods to arrow functions due to bug with `this` binding when using react hook
- Adds getter method to accommodate [useSyncExternalStore hook](https://react.dev/reference/react/useSyncExternalStore)
- Adds selectors for alerts and mnemonics
- Updates readme with Contacts Service example

I spoke with Joel about exporting the contactsById and Ids array versus exporting only the contacts array and he preferred to have the mapping be done on the library side and export the contactsById map/id array. I could see supplying a getSnapshot function that only does the contacts array if we find a performance need for it but right now having the object with contactsArray, contactsById, and contactIds array works well. I added selectors for alerts and mnemonics with the same exported structure. 