### PR TITLE
adds adjustable ranges for serious and caution status

### DIFF
--- a/src/lib/contacts/generate-contact.ts
+++ b/src/lib/contacts/generate-contact.ts
@@ -2,14 +2,7 @@ import { faker } from '@faker-js/faker';
 
 import dataOption from '../../data/options';
 import percentages from '../../data/percentages';
-import {
-  Contact,
-  ContactOptions,
-  Status,
-  Priority,
-  Mode,
-  Mnemonic,
-} from '../../types';
+import { Contact, ContactOptions, Status, Priority, Mode } from '../../types';
 import { generateAlert } from '../alerts/generate-alert';
 import { generateSubsystems } from '../subsystems/generate-subsystems';
 import {

--- a/src/lib/mnemonics/generate-mnemonic.ts
+++ b/src/lib/mnemonics/generate-mnemonic.ts
@@ -4,41 +4,55 @@ import dataOption from '../../data/options';
 import { shuffle, evaluateStatus } from '../../utils';
 import type { MnemonicOptions, Mnemonic } from '../../types/index';
 
-export const generateMnemonic = (options: MnemonicOptions): Mnemonic => {
-  const max = options?.thresholdMax || 110;
-  const min = options?.thresholdMin || 0;
+export const generateMnemonic = (options?: MnemonicOptions): Mnemonic => {
+  // Passed Options
+  const thresholdMax = options?.thresholdMax || 100;
+  const thresholdMin = options?.thresholdMin || 0;
   const deviation = options?.deviation || 10;
   const precision = options?.precision || 0.1;
-  const subsystem = options.subsystem || shuffle(dataOption.subsystems);
+  const subsystem = options?.subsystem || shuffle(dataOption.subsystems);
   const childSubsystem =
-    options.childSubsystem || shuffle(dataOption.childSubSystems);
+    options?.childSubsystem || shuffle(dataOption.childSubSystems);
   const assemblyDevice =
-    options.assemblyDevice || shuffle(dataOption.assemblyDevices);
+    options?.assemblyDevice || shuffle(dataOption.assemblyDevices);
+  const seriousThresholdRange = options?.seriousThresholdRange || 5;
+  const cautionThresholdRange = options?.cautionThresholdRange || 10;
+  const contactRefId = options?.contactRefId || '';
+
+  //Derived Values
+  const id = faker.string.uuid();
+  const mnemonicId = faker.string.alpha({ length: 7, casing: 'upper' });
   const childSubSystemNum = faker.number.int({ min: 1, max: 2 });
   const unit = shuffle(dataOption.units);
   const assembly = unit === 'Volts' ? 'Voltage Monitor' : `Heater Switch Power`;
   const measurement = `${childSubsystem} ${childSubSystemNum} ${assembly}`;
   const currentValue = faker.number.float({
-    max: max + deviation,
-    min: min - deviation,
+    max: thresholdMax + deviation,
+    min: thresholdMin - deviation,
     precision,
   });
-  const status = evaluateStatus(currentValue, min, max, 5, 10);
+  const status = evaluateStatus(
+    currentValue,
+    thresholdMin,
+    thresholdMax,
+    seriousThresholdRange,
+    cautionThresholdRange,
+  );
 
   return {
-    id: faker.string.uuid(),
+    id,
     type: 'mnemonic',
-    mnemonicId: faker.string.alpha({ length: 7, casing: 'upper' }),
+    mnemonicId,
     status,
-    unit: unit,
-    thresholdMax: max,
-    thresholdMin: min,
+    unit,
+    thresholdMax,
+    thresholdMin,
     currentValue,
     subsystem,
     childSubsystem,
     assemblyDevice,
     measurement,
-    contactRefId: options?.contactRefId || '',
+    contactRefId,
     watched: false,
   };
 };

--- a/src/lib/mnemonics/generate-mnemonics.ts
+++ b/src/lib/mnemonics/generate-mnemonics.ts
@@ -3,5 +3,5 @@ import { generateMnemonic } from './generate-mnemonic';
 
 export const generateMnemonics = (
   length: number = 9,
-  options: MnemonicOptions,
+  options?: MnemonicOptions,
 ) => Array.from({ length }, () => generateMnemonic(options));

--- a/src/lib/subsystems/generate-assembly-device.ts
+++ b/src/lib/subsystems/generate-assembly-device.ts
@@ -11,12 +11,14 @@ export const generateAssemblyDevice = (
   subsystemOptions?: SubsystemOptions,
 ): AssemblyDevice => {
   const name = shuffle(dataOption.assemblyDevices);
-  const numOfMnemonics = subsystemOptions?.mnemonicsPerAssemblyDevice || 1;
+  const numOfMnemonics =
+    subsystemOptions?.assemblyDeviceOptions?.mnemonicsPerAssemblyDevice || 1;
   const mnemonics = generateMnemonics(numOfMnemonics, {
     contactRefId,
     subsystem,
     childSubsystem,
     assemblyDevice: name,
+    ...subsystemOptions?.mnemonicOptions,
   });
   const status = getMostSevereStatus(mnemonics);
 

--- a/src/types/mnemonic.ts
+++ b/src/types/mnemonic.ts
@@ -11,6 +11,8 @@ export type MnemonicOptions = {
   subsystem?: string;
   childSubsystem?: string;
   assemblyDevice?: string;
+  seriousThresholdRange?: number;
+  cautionThresholdRange?: number;
 };
 
 export type Mnemonic = {

--- a/src/types/subsystems.ts
+++ b/src/types/subsystems.ts
@@ -1,4 +1,4 @@
-import { Status, Mnemonic } from './index';
+import { Status, Mnemonic, MnemonicOptions } from './index';
 
 export type Subsystem = {
   name: string;
@@ -20,7 +20,12 @@ export type AssemblyDevice = {
   mnemonics: Mnemonic[];
 };
 
+export type AssemblyDeviceOptions = {
+  mnemonicsPerAssemblyDevice?: number;
+};
+
 export type SubsystemOptions = {
   desiredSubsystems?: string[];
-  mnemonicsPerAssemblyDevice?: number;
+  assemblyDeviceOptions?: AssemblyDeviceOptions;
+  mnemonicOptions?: MnemonicOptions;
 };


### PR DESCRIPTION
Our randomly generated status were too likely to be critical so I gave the option to set specific thresholds for serious and caution thresholds. Criticle status can be adjusted using the deviation option. 